### PR TITLE
Fix styling of icons in a span element with class big or hero

### DIFF
--- a/src/css/content/icons.css
+++ b/src/css/content/icons.css
@@ -49,7 +49,7 @@ svg:has(use[href*="icon"]) {
 .big {
   padding: 0.5rem;
 }
-.big > .svg.ds-icon,
+.big > svg.ds-icon,
 .big > svg:has(use[href*="icons"]) {
   height: 2.66rem;
 }
@@ -59,7 +59,7 @@ svg:has(use[href*="icon"]) {
 .hero {
   padding: 0.75rem;
 }
-.hero > .svg.ds-icon,
+.hero > svg.ds-icon,
 .hero > svg:has(use[href*="icons"]) {
   height: 4.5rem;
 }


### PR DESCRIPTION
Icons written as follows are not styled correctly:

```html
<span class="hero">
<svg xmlns="http://www.w3.org/2000/svg" class="ds-icon" width="29" height="29" viewBox="0 0 29 29" fill="none">
  <g stroke="var(--ds-icon-color, black)" stroke-linejoin="round" stroke-linecap="round" stroke-width="var(--ds-icon-stroke, 1)">
    <path d="M15 26.54C22.18 26.54 28 20.93 28 14.02C28 7.1 22.18 1.5 15 1.5C7.82 1.5 2 7.1 2 14.02C2 16.2 2.58 18.25 3.59 20.03L1 27.5L8.77 25.01C10.62 25.98 12.74 26.54 15 26.54Z"></path>
    <path d="m 14.5,17 v -2.75 c 0,0 5.06,-0.78 5.02,-3.94 C 19.49,7.44 16.67,6.07 13.21,6.66 9.58,7.29 9.5,10 9.5,10"></path>
    <path d="m 14.5,22.5 v -2"></path>
  </g>
</svg>
</span>
<span class="big">
<svg xmlns="http://www.w3.org/2000/svg" class="ds-icon" width="29" height="29" viewBox="0 0 29 29" fill="none">
  <g stroke="var(--ds-icon-color, black)" stroke-linejoin="round" stroke-linecap="round" stroke-width="var(--ds-icon-stroke, 1)">
    <path d="M15 26.54C22.18 26.54 28 20.93 28 14.02C28 7.1 22.18 1.5 15 1.5C7.82 1.5 2 7.1 2 14.02C2 16.2 2.58 18.25 3.59 20.03L1 27.5L8.77 25.01C10.62 25.98 12.74 26.54 15 26.54Z"></path>
    <path d="m 14.5,17 v -2.75 c 0,0 5.06,-0.78 5.02,-3.94 C 19.49,7.44 16.67,6.07 13.21,6.66 9.58,7.29 9.5,10 9.5,10"></path>
    <path d="m 14.5,22.5 v -2"></path>
  </g>
</svg>
```
